### PR TITLE
feat: formatação do título e padronização do texto

### DIFF
--- a/src/main/webapp/index.xhtml
+++ b/src/main/webapp/index.xhtml
@@ -15,14 +15,14 @@
             nome <h:inputText value="#{beanJFPessoa.nome}" size="30"/>
 
             <h:selectOneMenu value="#{beanJFPessoa.cidade}">
-                <f:selectItem itemValue="" itemLabel="=== Selecione uma Cidade ===" />
+                <f:selectItem itemValue="" itemLabel="Selecione uma Cidade" />
                 <f:selectItems value="#{beanJFCidade.all}" var="c" itemLabel="#{c.nome}" itemValue="#{c.id}" />
             </h:selectOneMenu>
             <h:commandButton value="[]" action="#{beanJFPessoa.newID()}" />
             <h:commandButton value="+" action="#{beanJFPessoa.add()}" />
         </h:form>
     <hr/>
-        <h2>== Lista de clientes cadastrados ==</h2>
+        <h1>Lista de clientes cadastrados</h1>
         <h:form>
             <h:dataTable value="#{beanJFPessoa.all}" var="pessoa">
                 <h:column>


### PR DESCRIPTION
O título “Lista de clientes cadastrados” está renderizado como um título <h2></h2>, o que não é recomendado, pois os títulos das páginas devem ser em <h1></h1>. Quanto a padronização do texto, os “==” em “=== Selecione uma Cidade ===” e “== Lista de clientes cadastrados ==” foram retirados para deixar a interface mais limpa, acessível e dentro do padrão HTML esperado.
