### PR TITLE
feat: mensagem de log na criação de EntityManager

### DIFF
--- a/src/main/java/com/cp/data/crud/BeanCrudCidade.java
+++ b/src/main/java/com/cp/data/crud/BeanCrudCidade.java
@@ -22,7 +22,7 @@ public class BeanCrudCidade extends AbstractCrud<Cidade> {
     protected EntityManager getEntityManager() {
         if (em == null) {
             em = Persistence.createEntityManagerFactory(EMNames.EMN1, EMNames.getEMN1Props()).createEntityManager();
-            AppLog.getInstance().info("Entity manager criado com sucesso");
+            AppLog.getInstance().info("Entity manager para Cidade criado com sucesso");
         }
         return em;
     }

--- a/src/main/java/com/cp/data/crud/BeanCrudPessoa.java
+++ b/src/main/java/com/cp/data/crud/BeanCrudPessoa.java
@@ -22,7 +22,7 @@ public class BeanCrudPessoa extends AbstractCrud<Pessoa> {
     protected EntityManager getEntityManager() {
         if (em == null) {
                 em = Persistence.createEntityManagerFactory(EMNames.EMN1, EMNames.getEMN1Props()).createEntityManager();
-                AppLog.getInstance().info("Entity manager criado com sucesso");
+                AppLog.getInstance().info("Entity manager para Pessoa criado com sucesso");
         }
         return em;
     }


### PR DESCRIPTION
As mensagens de log em BeanCrudPessoa e BeanCrudCidade indicam que as entidades foram criadas. Então essa mudança evidencia, explicitamente, qual das entidades foi criada. Assim facilitando a leitura dos logs, principalmente em ambientes onde diversos beans utilizam EntityManagers, permitindo identificar rapidamente a origem da conexão. Portanto, essa mudança prova seu valor ao passo que o sistema cresce ou que seja realocado para outros desenvolvedores.